### PR TITLE
Remove duplicate index drop to allow a `-V3` test

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,11 @@
 numpy
-Cython
+Cython==3.0.3
 pandas>=1.1.5
 xarray
 netcdf4
+geopandas
+pyarrow
 pyyaml
 toolz
 joblib
+deprecated

--- a/src/troute-nwm/src/nwm_routing/preprocess.py
+++ b/src/troute-nwm/src/nwm_routing/preprocess.py
@@ -1094,8 +1094,7 @@ def nwm_forcing_preprocess(
         reservoir_usgs_df = (
             usgs_df_15min.join(link_lake_df, how = 'inner').
             reset_index().
-            set_index('usgs_lake_id').
-            drop(['index'], axis = 1)
+            set_index('usgs_lake_id')
         )
         
         LOG.debug(


### PR DESCRIPTION
The minor changes in requirements.txt have been noted in other PRs. 

This is primarily a fix to what appears to be a duplicate `drop` in the dataframe development for the usgs da. 

After making this change, with the files associated with this PR, I could at least execute the test case for the Lower Colorado: 
``` sh
#From the repository root: 
cd test/LowerColorado_TX
python -m nwm_routing -f -V3 test_AnA.yaml
```